### PR TITLE
Add stealth share mode

### DIFF
--- a/pkg/conf/conf.go
+++ b/pkg/conf/conf.go
@@ -29,6 +29,7 @@ type system struct {
 	HashIDSalt    string
 	GracePeriod   int    `validate:"gte=0"`
 	ProxyHeader   string `validate:"required_with=Listen"`
+	StealthShare  bool
 }
 
 type ssl struct {
@@ -53,7 +54,7 @@ type slave struct {
 type redis struct {
 	Network  string
 	Server   string
-	User	 string
+	User     string
 	Password string
 	DB       string
 }
@@ -77,6 +78,7 @@ Mode = master
 Listen = :5212
 SessionSecret = {SessionSecret}
 HashIDSalt = {HashIDSalt}
+StealthShare = true
 `
 
 // Init 初始化配置文件

--- a/pkg/conf/defaults.go
+++ b/pkg/conf/defaults.go
@@ -19,10 +19,11 @@ var DatabaseConfig = &database{
 
 // SystemConfig 系统公用配置
 var SystemConfig = &system{
-	Debug:       false,
-	Mode:        "master",
-	Listen:      ":5212",
-	ProxyHeader: "X-Forwarded-For",
+	Debug:        false,
+	Mode:         "master",
+	Listen:       ":5212",
+	ProxyHeader:  "X-Forwarded-For",
+	StealthShare: true,
 }
 
 // CORSConfig 跨域配置

--- a/service/share/manage.go
+++ b/service/share/manage.go
@@ -5,8 +5,10 @@ import (
 	"time"
 
 	model "github.com/cloudreve/Cloudreve/v3/models"
+	"github.com/cloudreve/Cloudreve/v3/pkg/conf"
 	"github.com/cloudreve/Cloudreve/v3/pkg/hashid"
 	"github.com/cloudreve/Cloudreve/v3/pkg/serializer"
+	"github.com/cloudreve/Cloudreve/v3/pkg/util"
 	"github.com/gin-gonic/gin"
 )
 
@@ -112,6 +114,13 @@ func (service *ShareCreateService) Create(c *gin.Context) serializer.Response {
 		return serializer.Err(serializer.CodeNotFound, "", nil)
 	}
 
+	// 强制密码分享
+	if conf.SystemConfig.StealthShare {
+		if service.Password == "" {
+			service.Password = util.RandStringRunes(6)
+		}
+	}
+
 	newShare := model.Share{
 		Password:        service.Password,
 		IsDir:           service.IsDir,
@@ -141,6 +150,12 @@ func (service *ShareCreateService) Create(c *gin.Context) serializer.Response {
 	siteURL := model.GetSiteURL()
 	sharePath, _ := url.Parse("/s/" + uid)
 	shareURL := siteURL.ResolveReference(sharePath)
+
+	if service.Password != "" {
+		q := shareURL.Query()
+		q.Set("password", service.Password)
+		shareURL.RawQuery = q.Encode()
+	}
 
 	return serializer.Response{
 		Code: 0,

--- a/service/share/visit.go
+++ b/service/share/visit.go
@@ -7,6 +7,7 @@ import (
 	"path"
 
 	model "github.com/cloudreve/Cloudreve/v3/models"
+	"github.com/cloudreve/Cloudreve/v3/pkg/conf"
 	"github.com/cloudreve/Cloudreve/v3/pkg/filesystem"
 	"github.com/cloudreve/Cloudreve/v3/pkg/filesystem/fsctx"
 	"github.com/cloudreve/Cloudreve/v3/pkg/hashid"
@@ -57,6 +58,13 @@ func (service *ShareUserGetService) Get(c *gin.Context) serializer.Response {
 		return serializer.Err(serializer.CodeNotFound, "", err)
 	}
 
+	if conf.SystemConfig.StealthShare {
+		current, exists := c.Get("user")
+		if !exists || (current.(*model.User).ID != user.ID && current.(*model.User).Group.ID != 1 && current.(*model.User).ID != 1) {
+			return serializer.Err(serializer.CodeNotFound, "", nil)
+		}
+	}
+
 	// 列出分享
 	hotNum := model.GetIntSetting("hot_share_num", 10)
 	if service.Type == "default" {
@@ -90,6 +98,9 @@ func (service *ShareUserGetService) Get(c *gin.Context) serializer.Response {
 
 // Search 搜索公共分享
 func (service *ShareListService) Search(c *gin.Context) serializer.Response {
+	if conf.SystemConfig.StealthShare {
+		return serializer.Err(serializer.CodeNotFound, "", nil)
+	}
 	// 列出分享
 	shares, total := model.SearchShares(int(service.Page), 18, service.OrderBy+" "+
 		service.Order, service.Keywords)


### PR DESCRIPTION
## Summary
- add `StealthShare` switch in system config with default true
- block share search and profile access when stealth mode enabled
- enforce random password and include it in share URL

## Testing
- `go test ./...` *(fails: TestFileSystem_Decompress)*

------
https://chatgpt.com/codex/tasks/task_e_684a8947813c83249870de0a5c3103e5